### PR TITLE
[FIX] RCE escaping commands

### DIFF
--- a/lib/webbynode/notify.rb
+++ b/lib/webbynode/notify.rb
@@ -8,7 +8,7 @@ module Webbynode
     def self.message(message)
       if self.installed? and !$testing
         message = message.gsub(/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]/, "")
-        %x(growlnotify -t "#{TITLE}" -m "#{%Q(#{message})}" --image "#{IMAGE_PATH}")
+        system("growlnotify", "-t", TITLE, "-m", message, "--image", IMAGE_PATH)
       end
     end
     

--- a/lib/webbynode/notify.rb
+++ b/lib/webbynode/notify.rb
@@ -8,7 +8,7 @@ module Webbynode
     def self.message(message)
       if self.installed? and !$testing
         message = message.gsub(/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]/, "")
-        %x(growlnotify -t "#{TITLE}" -m "#{%w(message)}" --image "#{IMAGE_PATH}")
+        %x(growlnotify -t "#{TITLE}" -m "#{%Q(message)}" --image "#{IMAGE_PATH}")
       end
     end
     

--- a/lib/webbynode/notify.rb
+++ b/lib/webbynode/notify.rb
@@ -8,7 +8,7 @@ module Webbynode
     def self.message(message)
       if self.installed? and !$testing
         message = message.gsub(/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]/, "")
-        %x(growlnotify -t "#{TITLE}" -m "#{%Q(message)}" --image "#{IMAGE_PATH}")
+        %x(growlnotify -t "#{TITLE}" -m "#{%Q(#{message})}" --image "#{IMAGE_PATH}")
       end
     end
     

--- a/lib/webbynode/notify.rb
+++ b/lib/webbynode/notify.rb
@@ -8,7 +8,7 @@ module Webbynode
     def self.message(message)
       if self.installed? and !$testing
         message = message.gsub(/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]/, "")
-        %x(growlnotify -t "#{TITLE}" -m "#{message}" --image "#{IMAGE_PATH}")
+        %x(growlnotify -t "#{TITLE}" -m "#{%w(message)}" --image "#{IMAGE_PATH}")
       end
     end
     


### PR DESCRIPTION
#### Bounty URL: https://www.huntr.dev/bounties/1-rubygems-webbynode

### ⚙️ Description *

The `gem` suffered of a `RCE` issue leading to `OS command injection` because `user-supplied` inputs were formatted inside a string executed through the `%x` operator without further validation.

### 💻 Technical Description *

I used the `system` function to securely handle the `user supplied "message" variable`, in order to avoid `quote` bypasses. The function handles the `first` string as the program to call and the other strings are instead used as `arguments` to pass to that argument (similar to `execFile()` in Node, you can read more here: https://medium.com/@bandanapandey11/command-injection-in-rails-e6b20e50918d).

### 🐛 Proof of Concept (PoC) *

No PoC was provided, however I've done some tests with the lines I fixed:

![Screenshot from 2020-08-06 15-52-31](https://user-images.githubusercontent.com/33063403/89540510-6803d200-d7fd-11ea-859f-6dd8fe329557.png)

### 🔥 Proof of Fix (PoF) *

No file is created using the `system` function in that way :smile:

### 👍 User Acceptance Testing (UAT)

Still works perfectly as `%x` is a pattern to identify the `backticks` and `system` as well (different way to process output, but still working: https://stackoverflow.com/questions/6338908/ruby-difference-between-exec-system-and-x-or-backticks) :smile: