### PR TITLE
Fix arbitrary command execution

### DIFF
--- a/lib/webbynode.rb
+++ b/lib/webbynode.rb
@@ -8,6 +8,7 @@ require 'net/ssh'
 require 'highline/import'
 require 'readline'
 require 'rainbow'
+require 'shellwords'
 
 begin
   require 'Win32/Console/ANSI' if RUBY_PLATFORM =~ /mswin/

--- a/lib/webbynode/notify.rb
+++ b/lib/webbynode/notify.rb
@@ -8,7 +8,7 @@ module Webbynode
     def self.message(message)
       if self.installed? and !$testing
         message = message.gsub(/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]/, "")
-        %x(growlnotify -t "#{TITLE}" -m "#{message}" --image "#{IMAGE_PATH}")
+        %x(growlnotify -t "#{TITLE.shellescape}" -m "#{message.shellescape}" --image "#{IMAGE_PATH.shellescape}")
       end
     end
     


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-rubygems-webbynode

### ⚙️ Description *

`webbynode` is a Webbynode Deployment Gem. This Gem contains a vulnerability in `notify.rb` that is triggered when handling a specially crafted `growlnotify` message. This can allow a context-dependent attacker to execute arbitrary commands. This is fixed by escaping the arguments of growlnotify using the module `shellwords`.

### 💻 Technical Description *

The implementation of executing `growlnotify` command in `notify.rb` was directly accepting input arguments without any escaping/sanitization making it vulnerable arbitrary command execution.

This is fixed by importing the Ruby module [`shellwords`](https://ruby-doc.org/stdlib-2.5.1/libdoc/shellwords/rdoc/Shellwords.html) and using its method `shellwords::shellescape`.

```ruby
def self.message(message)
  if self.installed? and !$testing
    message = message.gsub(/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]/, "")
    %x(growlnotify -t "#{TITLE.shellescape}" -m "#{message.shellescape}" --image "#{IMAGE_PATH.shellescape}")
  end
end
```

### 🐛 Proof of Concept (PoC) *

The following code located in: `lib/webbynode/notify.rb` doesn't fully sanitize user-supplied input before passing it to the shell via %x.

Messages via the growlnotify command line can possibly be used to execute shell commands if the message contains shell metacharacters.

```ruby
def self.message(message)
 if self.installed? and !$testing
   message = message.gsub(/\x1B\[([0-9]{1,2}(;[0-9]{1,2})?)?[m|K]/, "")
   %x(growlnotify -t "#{TITLE}" -m "#{message}" --image "#{IMAGE_PATH}")
 end
end
```

The message.gsub regex strips ANSI encoded characters from the `#{message}` variable, it doesn't strip characters like `;&|` etc. If the attacker can control the contents of `#{message}`, `#{TITLE}`, or `#{IMAGE_PATH}` they can possibly inject shell commands and execute them as the client user.

### 🔥 Proof of Fix (PoF) *

Escaped both `message` and `IMAGE_PATH` argument input variables with `shellwords::shellescape`.

### 👍 User Acceptance Testing (UAT)

_No `test` scripts and the only change introduced is a module import._
